### PR TITLE
add fp64 and pure fp32 support and format the output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+.DS_Store

--- a/mma.py
+++ b/mma.py
@@ -1,0 +1,184 @@
+"""
+JAX-based matrix multiply throughput benchmark.
+
+The script mirrors the mmapeak timing pattern in Python/JAX to avoid CUDA
+compilation overhead while keeping a comparable measurement loop.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from typing import Callable, Iterable, List, Tuple
+
+import jax
+import jax.numpy as jnp
+from jax import config as jax_config
+
+jax_config.update("jax_enable_x64", True)
+
+DEFAULT_TARGET_TIME = 3.0
+DEFAULT_MATMUL_SIZE = 4096
+
+
+def print_heading(title: str, separator: str = "-") -> None:
+    """
+    Print a centered heading line for readability.
+
+    Parameters
+    ----------
+    title : str
+        Title to display.
+    separator : str
+        Single-character separator used on both sides.
+    """
+
+    left = separator * 20
+    right = separator * 20
+    print(f"\n{left} {title} {right}")
+
+
+def build_matmul(dtype: jnp.dtype, size: int) -> Tuple[Callable[[], jnp.ndarray], int]:
+    """
+    Create a JIT-compiled matrix multiplication closure with fixed operands.
+
+    Parameters
+    ----------
+    dtype : jnp.dtype
+        Data type for operands.
+    size : int
+        Matrix dimension (square matrices of shape (size, size)).
+
+    Returns
+    -------
+    callable
+        Zero-argument callable executing the matmul and returning the result.
+    int
+        Effective floating-point operations per call (2 * size^3).
+    """
+
+    key_a, key_b = jax.random.split(jax.random.PRNGKey(0))
+    if jnp.issubdtype(dtype, jnp.integer):
+        a = jax.random.randint(key_a, (size, size), -2, 3, dtype=dtype)
+        b = jax.random.randint(key_b, (size, size), -2, 3, dtype=dtype)
+    else:
+        a = jax.random.normal(key_a, (size, size), dtype=dtype)
+        b = jax.random.normal(key_b, (size, size), dtype=dtype)
+
+    @jax.jit
+    def _matmul(x: jnp.ndarray, y: jnp.ndarray) -> jnp.ndarray:
+        return x @ y
+
+    def _run() -> jnp.ndarray:
+        return _matmul(a, b)
+
+    # Trigger compilation before benchmarking.
+    _ = _run().block_until_ready()
+    ops = 2 * size * size * size
+    return _run, ops
+
+
+def benchmark(op: Callable[[], jnp.ndarray], ops_per_call: int, target_time: float) -> Tuple[float, float]:
+    """
+    Benchmark a callable using a two-phase timing loop (calibrate then measure).
+
+    Parameters
+    ----------
+    op : callable
+        Zero-argument callable to benchmark. Must return a JAX array.
+    ops_per_call : int
+        Floating-point operations executed per call.
+    target_time : float
+        Target wall-clock time for measurement in seconds.
+
+    Returns
+    -------
+    float
+        Total elapsed time during the measurement phase in milliseconds.
+    float
+        Throughput in TFLOP/s.
+    """
+
+    n_loop = 8
+
+    def _run_loops(count: int) -> float:
+        start = time.perf_counter()
+        for _ in range(count):
+            _ = op().block_until_ready()
+        end = time.perf_counter()
+        return end - start
+
+    calibrate = _run_loops(n_loop)
+    n_loop = max(int(target_time / calibrate * n_loop), 1)
+
+    measured = _run_loops(n_loop)
+    t_ms = measured * 1e3
+    tflops = (ops_per_call * n_loop) / measured / 1e12
+    return t_ms, tflops
+
+
+def run_group(title: str, tests: Iterable[Tuple[str, jnp.dtype]], size: int, target_time: float) -> None:
+    """
+    Execute and print a group of benchmarks.
+
+    Parameters
+    ----------
+    title : str
+        Group title.
+    tests : Iterable[Tuple[str, jnp.dtype]]
+        Iterable of (label, dtype) pairs.
+    size : int
+        Matrix dimension.
+    target_time : float
+        Target wall time per benchmark.
+    """
+
+    print_heading(title, "=" if "INT" in title else "-")
+    for label, dtype in tests:
+        op, ops = build_matmul(dtype, size)
+        t_ms, tflops = benchmark(op, ops, target_time)
+        print(f"{label}: {t_ms:.1f} ms {tflops:.1f} T(fl)ops")
+
+
+def main() -> None:
+    """
+    Entry point for the JAX mmapeak benchmark.
+    """
+
+    parser = argparse.ArgumentParser(description="JAX mmapeak-style matmul benchmark")
+    parser.add_argument(
+        "-t",
+        "--target-time",
+        type=float,
+        default=DEFAULT_TARGET_TIME,
+        help=f"target time per benchmark in seconds (default: {DEFAULT_TARGET_TIME})",
+    )
+    parser.add_argument(
+        "-s",
+        "--size",
+        type=int,
+        default=DEFAULT_MATMUL_SIZE,
+        help=f"matrix dimension for square matmul (default: {DEFAULT_MATMUL_SIZE})",
+    )
+    args = parser.parse_args()
+
+    float_tests: List[Tuple[str, jnp.dtype]] = [
+        ("mm_jax_fp16", jnp.float16),
+        ("mm_jax_bf16", jnp.bfloat16),
+        ("mm_jax_fp32", jnp.float32),
+        ("mm_jax_fp64", jnp.float64),
+    ]
+    int_tests: List[Tuple[str, jnp.dtype]] = [
+        ("mm_jax_int8", jnp.int8),
+        ("mm_jax_int32", jnp.int32),
+    ]
+
+    print(f"Using JAX platform: {jax.default_backend()}")
+    print(f"Matrix size: {args.size}x{args.size}, target time: {args.target_time:.1f}s")
+
+    run_group("INT", int_tests, args.size, args.target_time)
+    run_group("FLOAT", float_tests, args.size, args.target_time)
+
+
+if __name__ == "__main__":
+    main()

--- a/mmapeak.cu
+++ b/mmapeak.cu
@@ -1,4 +1,8 @@
-// nvcc -O2 mmapeak.cu -gencode arch=compute_75,code=sm_75 -gencode arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode arch=compute_89,code=sm_89 -gencode arch=compute_90,code=sm_90 -gencode arch=compute_110f,code=sm_110 -gencode arch=compute_120f,code=sm_120 -o mmapeak
+// nvcc -O2 mmapeak.cu -gencode arch=compute_75,code=sm_75 -gencode
+// arch=compute_80,code=sm_80 -gencode arch=compute_86,code=sm_86 -gencode
+// arch=compute_89,code=sm_89 -gencode arch=compute_90,code=sm_90 -gencode
+// arch=compute_110f,code=sm_110 -gencode arch=compute_120f,code=sm_120 -o
+// mmapeak
 
 #include <cuda.h>
 #include <mma.h>
@@ -7,17 +11,18 @@
 #endif
 // Consumer Blackwell (>= SM120) only
 // TODO: Support SM100 and SM110
-#if __CUDA_ARCH__ >= 1200 && \
-    !(__CUDACC_VER_MAJOR__ < 12 || \
-        (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ < 8) || \
-        (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ == 8 && __CUDACC_VER_BUILD__ < 90))
+#if __CUDA_ARCH__ >= 1200 &&                                                   \
+    !(__CUDACC_VER_MAJOR__ < 12 ||                                             \
+      (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ < 8) ||              \
+      (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ == 8 &&              \
+       __CUDACC_VER_BUILD__ < 90))
 #define ENABLE_BLACKWELL 1
 #endif
 #if ENABLE_BLACKWELL
 #include <cuda_fp4.h>
 #endif
-#include <stdio.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 using namespace nvcuda::wmma;
@@ -26,685 +31,730 @@ using namespace nvcuda::wmma;
 #define N_LOOP_CALIB 128
 #define DEFAULT_TARGET_TIME 3.0f
 
-template <typename InputType, typename OutputType, unsigned M, unsigned N, unsigned K>
-__device__ void mma_(OutputType *data)
-{
-    fragment<accumulator, M, N, K, OutputType> d;
-    fragment<matrix_a, M, N, K, InputType, row_major> a;
-    fragment<matrix_b, M, N, K, InputType, col_major> b;
-    fill_fragment(d, 0);
-    fill_fragment(a, 0);
-    fill_fragment(b, 0);
-    for (unsigned k = 0; k < N_LOOP_INTERNAL; k++)
-    {
-        mma_sync(d, a, b, d);
-        __syncwarp();
-    }
-    OutputType *ptr = &data[threadIdx.y * M * N];
-    store_matrix_sync(ptr, d, N, mem_row_major);
+template <typename InputType, typename OutputType, unsigned M, unsigned N,
+          unsigned K>
+__device__ void mma_(OutputType *data) {
+  fragment<accumulator, M, N, K, OutputType> d;
+  fragment<matrix_a, M, N, K, InputType, row_major> a;
+  fragment<matrix_b, M, N, K, InputType, col_major> b;
+  fill_fragment(d, 0);
+  fill_fragment(a, 0);
+  fill_fragment(b, 0);
+  for (unsigned k = 0; k < N_LOOP_INTERNAL; k++) {
+    mma_sync(d, a, b, d);
+    __syncwarp();
+  }
+  OutputType *ptr = &data[threadIdx.y * M * N];
+  store_matrix_sync(ptr, d, N, mem_row_major);
 }
 
 inline __device__ void mma_s4_(
     fragment<accumulator, 8, 8, 32, int> &d,
-    const fragment<matrix_a, 8, 8, 32, experimental::precision::s4, row_major> &
-        a,
-    const fragment<matrix_b, 8, 8, 32, experimental::precision::s4, col_major> &
-        b,
-    const fragment<accumulator, 8, 8, 32, int> &c)
-{
-    asm volatile(
-        "mma.sync.aligned.row.col.m8n8k32.s32.s4.s4.s32 {%0, %1}, {%2}, {%3}, "
-        "{%4, %5};\n"
-        : "=r"(d.x[0]), "=r"(d.x[1])
-        : "r"(a.x[0]), "r"(b.x[0]), "r"(c.x[0]), "r"(c.x[1]));
+    const fragment<matrix_a, 8, 8, 32, experimental::precision::s4, row_major>
+        &a,
+    const fragment<matrix_b, 8, 8, 32, experimental::precision::s4, col_major>
+        &b,
+    const fragment<accumulator, 8, 8, 32, int> &c) {
+  asm volatile(
+      "mma.sync.aligned.row.col.m8n8k32.s32.s4.s4.s32 {%0, %1}, {%2}, {%3}, "
+      "{%4, %5};\n"
+      : "=r"(d.x[0]), "=r"(d.x[1])
+      : "r"(a.x[0]), "r"(b.x[0]), "r"(c.x[0]), "r"(c.x[1]));
 }
 
-template <typename InputType, typename OutputType, unsigned M, unsigned N, unsigned K>
-__device__ void mma_s4_(OutputType *data)
-{
-    fragment<accumulator, M, N, K, OutputType> d;
-    fragment<matrix_a, M, N, K, InputType, row_major> a;
-    fragment<matrix_b, M, N, K, InputType, col_major> b;
-    fill_fragment(d, 0);
-    fill_fragment(a, 0);
-    fill_fragment(b, 0);
-    for (unsigned k = 0; k < N_LOOP_INTERNAL; k++)
-    {
-        mma_s4_(d, a, b, d);
-        __syncwarp();
-    }
-    OutputType *ptr = &data[threadIdx.y * M * N];
-    store_matrix_sync(ptr, d, N, mem_row_major);
+template <typename InputType, typename OutputType, unsigned M, unsigned N,
+          unsigned K>
+__device__ void mma_s4_(OutputType *data) {
+  fragment<accumulator, M, N, K, OutputType> d;
+  fragment<matrix_a, M, N, K, InputType, row_major> a;
+  fragment<matrix_b, M, N, K, InputType, col_major> b;
+  fill_fragment(d, 0);
+  fill_fragment(a, 0);
+  fill_fragment(b, 0);
+  for (unsigned k = 0; k < N_LOOP_INTERNAL; k++) {
+    mma_s4_(d, a, b, d);
+    __syncwarp();
+  }
+  OutputType *ptr = &data[threadIdx.y * M * N];
+  store_matrix_sync(ptr, d, N, mem_row_major);
 }
 
 #if ENABLE_BLACKWELL
-__device__ void mma_mxf4mxf4f32_16_8_64_(float *data)
-{
-    uint32_t d[4] = {0};
-    uint32_t a[4] = {0};
-    uint32_t b[2] = {0};
-    uint32_t sa = 0;
-    uint32_t sb = 0;
-    static constexpr uint16_t bid_a = 0;
-    static constexpr uint16_t tid_a = 0;
-    static constexpr uint16_t bid_b = 0;
-    static constexpr uint16_t tid_b = 0;
-    for (unsigned k = 0; k < N_LOOP_INTERNAL; k++)
-    {
-        asm volatile(
-            "mma.sync.aligned.m16n8k64.row.col.kind::mxf4.block_scale.scale_vec::2X.f32.e2m1.e2m1.f32.ue8m0 "
-            "{%0, %1, %2, %3}, "
-            "{%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13}, "
-            "%14, {%15, %16}, %17, {%18, %19};\n"
-            : "=r"(d[0]), "=r"(d[1]), "=r"(d[2]), "=r"(d[3])
-            : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
-              "r"(b[0]), "r"(b[1]),
-              "r"(d[0]), "r"(d[1]), "r"(d[2]), "r"(d[3]),
-              "r"(sa), "h"(bid_a), "h"(tid_a),
-              "r"(sb), "h"(bid_b), "h"(tid_b));
-        __syncwarp();
-    }
-    asm volatile(
-        "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::"l"(data), "r"(d[0]), "r"(d[1]));
-    asm volatile(
-        "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::"l"(data + 64), "r"(d[2]), "r"(d[3]));
+__device__ void mma_mxf4mxf4f32_16_8_64_(float *data) {
+  uint32_t d[4] = {0};
+  uint32_t a[4] = {0};
+  uint32_t b[2] = {0};
+  uint32_t sa = 0;
+  uint32_t sb = 0;
+  static constexpr uint16_t bid_a = 0;
+  static constexpr uint16_t tid_a = 0;
+  static constexpr uint16_t bid_b = 0;
+  static constexpr uint16_t tid_b = 0;
+  for (unsigned k = 0; k < N_LOOP_INTERNAL; k++) {
+    asm volatile("mma.sync.aligned.m16n8k64.row.col.kind::mxf4.block_scale."
+                 "scale_vec::2X.f32.e2m1.e2m1.f32.ue8m0 "
+                 "{%0, %1, %2, %3}, "
+                 "{%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13}, "
+                 "%14, {%15, %16}, %17, {%18, %19};\n"
+                 : "=r"(d[0]), "=r"(d[1]), "=r"(d[2]), "=r"(d[3])
+                 : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]),
+                   "r"(b[1]), "r"(d[0]), "r"(d[1]), "r"(d[2]), "r"(d[3]),
+                   "r"(sa), "h"(bid_a), "h"(tid_a), "r"(sb), "h"(bid_b),
+                   "h"(tid_b));
+    __syncwarp();
+  }
+  asm volatile(
+      "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::
+          "l"(data),
+      "r"(d[0]), "r"(d[1]));
+  asm volatile(
+      "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::
+          "l"(data + 64),
+      "r"(d[2]), "r"(d[3]));
 }
 
-__device__ void mma_nvf4nvf4f32_16_8_64_(float *data)
-{
-    uint32_t d[4] = {0};
-    uint32_t a[4] = {0};
-    uint32_t b[2] = {0};
-    uint32_t sa = 0;
-    uint32_t sb = 0;
-    static constexpr uint16_t bid_a = 0;
-    static constexpr uint16_t tid_a = 0;
-    static constexpr uint16_t bid_b = 0;
-    static constexpr uint16_t tid_b = 0;
-    for (unsigned k = 0; k < N_LOOP_INTERNAL; k++)
-    {
-        asm volatile(
-            "mma.sync.aligned.m16n8k64.row.col.kind::mxf4nvf4.block_scale.scale_vec::4X.f32.e2m1.e2m1.f32.ue4m3 "
-            "{%0, %1, %2, %3}, "
-            "{%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13}, "
-            "%14, {%15, %16}, %17, {%18, %19};\n"
-            : "=r"(d[0]), "=r"(d[1]), "=r"(d[2]), "=r"(d[3])
-            : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
-              "r"(b[0]), "r"(b[1]),
-              "r"(d[0]), "r"(d[1]), "r"(d[2]), "r"(d[3]),
-              "r"(sa), "h"(bid_a), "h"(tid_a),
-              "r"(sb), "h"(bid_b), "h"(tid_b));
-        __syncwarp();
-    }
-    asm volatile(
-        "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::"l"(data), "r"(d[0]), "r"(d[1]));
-    asm volatile(
-        "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::"l"(data + 64), "r"(d[2]), "r"(d[3]));
+__device__ void mma_nvf4nvf4f32_16_8_64_(float *data) {
+  uint32_t d[4] = {0};
+  uint32_t a[4] = {0};
+  uint32_t b[2] = {0};
+  uint32_t sa = 0;
+  uint32_t sb = 0;
+  static constexpr uint16_t bid_a = 0;
+  static constexpr uint16_t tid_a = 0;
+  static constexpr uint16_t bid_b = 0;
+  static constexpr uint16_t tid_b = 0;
+  for (unsigned k = 0; k < N_LOOP_INTERNAL; k++) {
+    asm volatile("mma.sync.aligned.m16n8k64.row.col.kind::mxf4nvf4.block_scale."
+                 "scale_vec::4X.f32.e2m1.e2m1.f32.ue4m3 "
+                 "{%0, %1, %2, %3}, "
+                 "{%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13}, "
+                 "%14, {%15, %16}, %17, {%18, %19};\n"
+                 : "=r"(d[0]), "=r"(d[1]), "=r"(d[2]), "=r"(d[3])
+                 : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]),
+                   "r"(b[1]), "r"(d[0]), "r"(d[1]), "r"(d[2]), "r"(d[3]),
+                   "r"(sa), "h"(bid_a), "h"(tid_a), "r"(sb), "h"(bid_b),
+                   "h"(tid_b));
+    __syncwarp();
+  }
+  asm volatile(
+      "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::
+          "l"(data),
+      "r"(d[0]), "r"(d[1]));
+  asm volatile(
+      "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::
+          "l"(data + 64),
+      "r"(d[2]), "r"(d[3]));
 }
 
-__device__ void mma_f4f4f16_16_8_32_(half *data)
-{
-    uint32_t d[2] = {0};
-    uint32_t a[4] = {0};
-    uint32_t b[2] = {0};
-    for (unsigned k = 0; k < N_LOOP_INTERNAL; k++)
-    {
-        asm volatile(
-            "mma.sync.aligned.m16n8k32.row.col.kind::f8f6f4.f16.e2m1.e2m1.f16 {%0, %1}, {%2, %3, %4, %5}, {%6, %7}, "
-            "{%8, %9};\n"
-            : "=r"(d[0]), "=r"(d[1])
-            : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
-              "r"(b[0]), "r"(b[1]),
-              "r"(d[0]), "r"(d[1]));
-        __syncwarp();
-    }
-    asm volatile(
-        "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::"l"(data), "r"(d[0]), "r"(d[1]));
+__device__ void mma_f4f4f16_16_8_32_(half *data) {
+  uint32_t d[2] = {0};
+  uint32_t a[4] = {0};
+  uint32_t b[2] = {0};
+  for (unsigned k = 0; k < N_LOOP_INTERNAL; k++) {
+    asm volatile("mma.sync.aligned.m16n8k32.row.col.kind::f8f6f4.f16.e2m1.e2m1."
+                 "f16 {%0, %1}, {%2, %3, %4, %5}, {%6, %7}, "
+                 "{%8, %9};\n"
+                 : "=r"(d[0]), "=r"(d[1])
+                 : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]),
+                   "r"(b[1]), "r"(d[0]), "r"(d[1]));
+    __syncwarp();
+  }
+  asm volatile(
+      "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::
+          "l"(data),
+      "r"(d[0]), "r"(d[1]));
 }
 
-__device__ void mma_f4f4f32_16_8_32_(float *data)
-{
-    uint32_t d[4] = {0};
-    uint32_t a[4] = {0};
-    uint32_t b[2] = {0};
-    for (unsigned k = 0; k < N_LOOP_INTERNAL; k++)
-    {
-        asm volatile(
-            "mma.sync.aligned.m16n8k32.row.col.kind::f8f6f4.f32.e2m1.e2m1.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, "
-            "{%10, %11, %12, %13};\n"
-            : "=r"(d[0]), "=r"(d[1]), "=r"(d[2]), "=r"(d[3])
-            : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
-              "r"(b[0]), "r"(b[1]),
-              "r"(d[0]), "r"(d[1]), "r"(d[2]), "r"(d[3]));
-        __syncwarp();
-    }
-    asm volatile(
-        "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::"l"(data), "r"(d[0]), "r"(d[1]));
-    asm volatile(
-        "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::"l"(data + 64), "r"(d[2]), "r"(d[3]));
+__device__ void mma_f4f4f32_16_8_32_(float *data) {
+  uint32_t d[4] = {0};
+  uint32_t a[4] = {0};
+  uint32_t b[2] = {0};
+  for (unsigned k = 0; k < N_LOOP_INTERNAL; k++) {
+    asm volatile("mma.sync.aligned.m16n8k32.row.col.kind::f8f6f4.f32.e2m1.e2m1."
+                 "f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, "
+                 "{%10, %11, %12, %13};\n"
+                 : "=r"(d[0]), "=r"(d[1]), "=r"(d[2]), "=r"(d[3])
+                 : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]),
+                   "r"(b[1]), "r"(d[0]), "r"(d[1]), "r"(d[2]), "r"(d[3]));
+    __syncwarp();
+  }
+  asm volatile(
+      "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::
+          "l"(data),
+      "r"(d[0]), "r"(d[1]));
+  asm volatile(
+      "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::
+          "l"(data + 64),
+      "r"(d[2]), "r"(d[3]));
 }
 
-__device__ void mma_f6f6f16_16_8_32_(half *data)
-{
-    uint32_t d[2] = {0};
-    uint32_t a[4] = {0};
-    uint32_t b[2] = {0};
-    for (unsigned k = 0; k < N_LOOP_INTERNAL; k++)
-    {
-        asm volatile(
-            "mma.sync.aligned.m16n8k32.row.col.kind::f8f6f4.f16.e3m2.e3m2.f16 {%0, %1}, {%2, %3, %4, %5}, {%6, %7}, "
-            "{%8, %9};\n"
-            : "=r"(d[0]), "=r"(d[1])
-            : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
-              "r"(b[0]), "r"(b[1]),
-              "r"(d[0]), "r"(d[1]));
-        __syncwarp();
-    }
-    asm volatile(
-        "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::"l"(data), "r"(d[0]), "r"(d[1]));
+__device__ void mma_f6f6f16_16_8_32_(half *data) {
+  uint32_t d[2] = {0};
+  uint32_t a[4] = {0};
+  uint32_t b[2] = {0};
+  for (unsigned k = 0; k < N_LOOP_INTERNAL; k++) {
+    asm volatile("mma.sync.aligned.m16n8k32.row.col.kind::f8f6f4.f16.e3m2.e3m2."
+                 "f16 {%0, %1}, {%2, %3, %4, %5}, {%6, %7}, "
+                 "{%8, %9};\n"
+                 : "=r"(d[0]), "=r"(d[1])
+                 : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]),
+                   "r"(b[1]), "r"(d[0]), "r"(d[1]));
+    __syncwarp();
+  }
+  asm volatile(
+      "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::
+          "l"(data),
+      "r"(d[0]), "r"(d[1]));
 }
 
-__device__ void mma_f6f6f32_16_8_32_(float *data)
-{
-    uint32_t d[4] = {0};
-    uint32_t a[4] = {0};
-    uint32_t b[2] = {0};
-    for (unsigned k = 0; k < N_LOOP_INTERNAL; k++)
-    {
-        asm volatile(
-            "mma.sync.aligned.m16n8k32.row.col.kind::f8f6f4.f32.e3m2.e3m2.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, "
-            "{%10, %11, %12, %13};\n"
-            : "=r"(d[0]), "=r"(d[1]), "=r"(d[2]), "=r"(d[3])
-            : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
-              "r"(b[0]), "r"(b[1]),
-              "r"(d[0]), "r"(d[1]), "r"(d[2]), "r"(d[3]));
-        __syncwarp();
-    }
-    asm volatile(
-        "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::"l"(data), "r"(d[0]), "r"(d[1]));
-    asm volatile(
-        "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::"l"(data + 64), "r"(d[2]), "r"(d[3]));
+__device__ void mma_f6f6f32_16_8_32_(float *data) {
+  uint32_t d[4] = {0};
+  uint32_t a[4] = {0};
+  uint32_t b[2] = {0};
+  for (unsigned k = 0; k < N_LOOP_INTERNAL; k++) {
+    asm volatile("mma.sync.aligned.m16n8k32.row.col.kind::f8f6f4.f32.e3m2.e3m2."
+                 "f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, "
+                 "{%10, %11, %12, %13};\n"
+                 : "=r"(d[0]), "=r"(d[1]), "=r"(d[2]), "=r"(d[3])
+                 : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]),
+                   "r"(b[1]), "r"(d[0]), "r"(d[1]), "r"(d[2]), "r"(d[3]));
+    __syncwarp();
+  }
+  asm volatile(
+      "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::
+          "l"(data),
+      "r"(d[0]), "r"(d[1]));
+  asm volatile(
+      "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::
+          "l"(data + 64),
+      "r"(d[2]), "r"(d[3]));
 }
 
-__device__ void mma_mxf6mxf6f32_16_8_32_(float *data)
-{
-    uint32_t d[4] = {0};
-    uint32_t a[4] = {0};
-    uint32_t b[2] = {0};
-    uint32_t sa = 0;
-    uint32_t sb = 0;
-    static constexpr uint16_t bid_a = 0;
-    static constexpr uint16_t tid_a = 0;
-    static constexpr uint16_t bid_b = 0;
-    static constexpr uint16_t tid_b = 0;
-    for (unsigned k = 0; k < N_LOOP_INTERNAL; k++)
-    {
-        asm volatile(
-            "mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale.scale_vec::1X.f32.e3m2.e3m2.f32.ue8m0 "
-            "{%0, %1, %2, %3}, "
-            "{%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13}, "
-            "%14, {%15, %16}, %17, {%18, %19};\n"
-            : "=r"(d[0]), "=r"(d[1]), "=r"(d[2]), "=r"(d[3])
-            : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
-              "r"(b[0]), "r"(b[1]),
-              "r"(d[0]), "r"(d[1]), "r"(d[2]), "r"(d[3]),
-              "r"(sa), "h"(bid_a), "h"(tid_a),
-              "r"(sb), "h"(bid_b), "h"(tid_b));
-        __syncwarp();
-    }
-    asm volatile(
-        "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::"l"(data), "r"(d[0]), "r"(d[1]));
-    asm volatile(
-        "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::"l"(data + 64), "r"(d[2]), "r"(d[3]));
+__device__ void mma_mxf6mxf6f32_16_8_32_(float *data) {
+  uint32_t d[4] = {0};
+  uint32_t a[4] = {0};
+  uint32_t b[2] = {0};
+  uint32_t sa = 0;
+  uint32_t sb = 0;
+  static constexpr uint16_t bid_a = 0;
+  static constexpr uint16_t tid_a = 0;
+  static constexpr uint16_t bid_b = 0;
+  static constexpr uint16_t tid_b = 0;
+  for (unsigned k = 0; k < N_LOOP_INTERNAL; k++) {
+    asm volatile("mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale."
+                 "scale_vec::1X.f32.e3m2.e3m2.f32.ue8m0 "
+                 "{%0, %1, %2, %3}, "
+                 "{%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13}, "
+                 "%14, {%15, %16}, %17, {%18, %19};\n"
+                 : "=r"(d[0]), "=r"(d[1]), "=r"(d[2]), "=r"(d[3])
+                 : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]),
+                   "r"(b[1]), "r"(d[0]), "r"(d[1]), "r"(d[2]), "r"(d[3]),
+                   "r"(sa), "h"(bid_a), "h"(tid_a), "r"(sb), "h"(bid_b),
+                   "h"(tid_b));
+    __syncwarp();
+  }
+  asm volatile(
+      "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::
+          "l"(data),
+      "r"(d[0]), "r"(d[1]));
+  asm volatile(
+      "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::
+          "l"(data + 64),
+      "r"(d[2]), "r"(d[3]));
 }
 
-__device__ void mma_mxf8mxf8f32_16_8_32_(float *data)
-{
-    uint32_t d[4] = {0};
-    uint32_t a[4] = {0};
-    uint32_t b[2] = {0};
-    uint32_t sa = 0;
-    uint32_t sb = 0;
-    static constexpr uint16_t bid_a = 0;
-    static constexpr uint16_t tid_a = 0;
-    static constexpr uint16_t bid_b = 0;
-    static constexpr uint16_t tid_b = 0;
-    for (unsigned k = 0; k < N_LOOP_INTERNAL; k++)
-    {
-        asm volatile(
-            "mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale.scale_vec::1X.f32.e4m3.e4m3.f32.ue8m0 "
-            "{%0, %1, %2, %3}, "
-            "{%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13}, "
-            "%14, {%15, %16}, %17, {%18, %19};\n"
-            : "=r"(d[0]), "=r"(d[1]), "=r"(d[2]), "=r"(d[3])
-            : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
-              "r"(b[0]), "r"(b[1]),
-              "r"(d[0]), "r"(d[1]), "r"(d[2]), "r"(d[3]),
-              "r"(sa), "h"(bid_a), "h"(tid_a),
-              "r"(sb), "h"(bid_b), "h"(tid_b));
-        __syncwarp();
-    }
-    asm volatile(
-        "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::"l"(data), "r"(d[0]), "r"(d[1]));
-    asm volatile(
-        "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::"l"(data + 64), "r"(d[2]), "r"(d[3]));
+__device__ void mma_mxf8mxf8f32_16_8_32_(float *data) {
+  uint32_t d[4] = {0};
+  uint32_t a[4] = {0};
+  uint32_t b[2] = {0};
+  uint32_t sa = 0;
+  uint32_t sb = 0;
+  static constexpr uint16_t bid_a = 0;
+  static constexpr uint16_t tid_a = 0;
+  static constexpr uint16_t bid_b = 0;
+  static constexpr uint16_t tid_b = 0;
+  for (unsigned k = 0; k < N_LOOP_INTERNAL; k++) {
+    asm volatile("mma.sync.aligned.m16n8k32.row.col.kind::mxf8f6f4.block_scale."
+                 "scale_vec::1X.f32.e4m3.e4m3.f32.ue8m0 "
+                 "{%0, %1, %2, %3}, "
+                 "{%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13}, "
+                 "%14, {%15, %16}, %17, {%18, %19};\n"
+                 : "=r"(d[0]), "=r"(d[1]), "=r"(d[2]), "=r"(d[3])
+                 : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]),
+                   "r"(b[1]), "r"(d[0]), "r"(d[1]), "r"(d[2]), "r"(d[3]),
+                   "r"(sa), "h"(bid_a), "h"(tid_a), "r"(sb), "h"(bid_b),
+                   "h"(tid_b));
+    __syncwarp();
+  }
+  asm volatile(
+      "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::
+          "l"(data),
+      "r"(d[0]), "r"(d[1]));
+  asm volatile(
+      "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::
+          "l"(data + 64),
+      "r"(d[2]), "r"(d[3]));
 }
 #endif
 
 #if __CUDA_ARCH__ >= 890
-__device__ void mma_f8f8f16_16_8_32_(half *data)
-{
-    uint32_t d[2] = {0};
-    uint32_t a[4] = {0};
-    uint32_t b[2] = {0};
-    for (unsigned k = 0; k < N_LOOP_INTERNAL; k++)
-    {
-        asm volatile(
-            "mma.sync.aligned.m16n8k32.row.col.f16.e4m3.e4m3.f16 {%0, %1}, {%2, %3, %4, %5}, {%6, %7}, "
-            "{%8, %9};\n"
-            : "=r"(d[0]), "=r"(d[1])
-            : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
-              "r"(b[0]), "r"(b[1]),
-              "r"(d[0]), "r"(d[1]));
-        __syncwarp();
-    }
-    asm volatile(
-        "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::"l"(data), "r"(d[0]), "r"(d[1]));
+__device__ void mma_f8f8f16_16_8_32_(half *data) {
+  uint32_t d[2] = {0};
+  uint32_t a[4] = {0};
+  uint32_t b[2] = {0};
+  for (unsigned k = 0; k < N_LOOP_INTERNAL; k++) {
+    asm volatile("mma.sync.aligned.m16n8k32.row.col.f16.e4m3.e4m3.f16 {%0, "
+                 "%1}, {%2, %3, %4, %5}, {%6, %7}, "
+                 "{%8, %9};\n"
+                 : "=r"(d[0]), "=r"(d[1])
+                 : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]),
+                   "r"(b[1]), "r"(d[0]), "r"(d[1]));
+    __syncwarp();
+  }
+  asm volatile(
+      "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::
+          "l"(data),
+      "r"(d[0]), "r"(d[1]));
 }
 
-__device__ void mma_f8f8f32_16_8_32_(float *data)
-{
-    uint32_t d[4] = {0};
-    uint32_t a[4] = {0};
-    uint32_t b[2] = {0};
-    for (unsigned k = 0; k < N_LOOP_INTERNAL; k++)
-    {
-        asm volatile(
-            "mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, "
-            "{%10, %11, %12, %13};\n"
-            : "=r"(d[0]), "=r"(d[1]), "=r"(d[2]), "=r"(d[3])
-            : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]),
-              "r"(b[0]), "r"(b[1]),
-              "r"(d[0]), "r"(d[1]), "r"(d[2]), "r"(d[3]));
-        __syncwarp();
-    }
-    asm volatile(
-        "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::"l"(data), "r"(d[0]), "r"(d[1]));
-    asm volatile(
-        "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::"l"(data + 64), "r"(d[2]), "r"(d[3]));
+__device__ void mma_f8f8f32_16_8_32_(float *data) {
+  uint32_t d[4] = {0};
+  uint32_t a[4] = {0};
+  uint32_t b[2] = {0};
+  for (unsigned k = 0; k < N_LOOP_INTERNAL; k++) {
+    asm volatile("mma.sync.aligned.m16n8k32.row.col.f32.e4m3.e4m3.f32 {%0, %1, "
+                 "%2, %3}, {%4, %5, %6, %7}, {%8, %9}, "
+                 "{%10, %11, %12, %13};\n"
+                 : "=r"(d[0]), "=r"(d[1]), "=r"(d[2]), "=r"(d[3])
+                 : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b[0]),
+                   "r"(b[1]), "r"(d[0]), "r"(d[1]), "r"(d[2]), "r"(d[3]));
+    __syncwarp();
+  }
+  asm volatile(
+      "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::
+          "l"(data),
+      "r"(d[0]), "r"(d[1]));
+  asm volatile(
+      "wmma.store.d.sync.aligned.row.m8n8k32.global.s32 [%0], {%1, %2};\n" ::
+          "l"(data + 64),
+      "r"(d[2]), "r"(d[3]));
 }
 #endif
 
-__global__ void mma_s4s4s32_8_8_32(void *data, int *rc)
-{
-    mma_s4_<experimental::precision::s4, int, 8, 8, 32>((int *)data);
-    *rc = 0;
+__global__ void mma_s4s4s32_8_8_32(void *data, int *rc) {
+  mma_s4_<experimental::precision::s4, int, 8, 8, 32>((int *)data);
+  *rc = 0;
 }
 
 #if ENABLE_BLACKWELL
-__global__ void mma_mxf4mxf4f32_16_8_64(void *data, int *rc)
-{
-    mma_mxf4mxf4f32_16_8_64_((float *)data);
-    *rc = 0;
+__global__ void mma_mxf4mxf4f32_16_8_64(void *data, int *rc) {
+  mma_mxf4mxf4f32_16_8_64_((float *)data);
+  *rc = 0;
 }
 
-__global__ void mma_nvf4nvf4f32_16_8_64(void *data, int *rc)
-{
-    mma_nvf4nvf4f32_16_8_64_((float *)data);
-    *rc = 0;
+__global__ void mma_nvf4nvf4f32_16_8_64(void *data, int *rc) {
+  mma_nvf4nvf4f32_16_8_64_((float *)data);
+  *rc = 0;
 }
 
-__global__ void mma_f4f4f16_16_8_32(void *data, int *rc)
-{
-    mma_f4f4f16_16_8_32_((half *)data);
-    *rc = 0;
+__global__ void mma_f4f4f16_16_8_32(void *data, int *rc) {
+  mma_f4f4f16_16_8_32_((half *)data);
+  *rc = 0;
 }
 
-__global__ void mma_f4f4f32_16_8_32(void *data, int *rc)
-{
-    mma_f4f4f32_16_8_32_((float *)data);
-    *rc = 0;
+__global__ void mma_f4f4f32_16_8_32(void *data, int *rc) {
+  mma_f4f4f32_16_8_32_((float *)data);
+  *rc = 0;
 }
 
-__global__ void mma_f6f6f16_16_8_32(void *data, int *rc)
-{
-    mma_f6f6f16_16_8_32_((half *)data);
-    *rc = 0;
+__global__ void mma_f6f6f16_16_8_32(void *data, int *rc) {
+  mma_f6f6f16_16_8_32_((half *)data);
+  *rc = 0;
 }
 
-__global__ void mma_f6f6f32_16_8_32(void *data, int *rc)
-{
-    mma_f6f6f32_16_8_32_((float *)data);
-    *rc = 0;
+__global__ void mma_f6f6f32_16_8_32(void *data, int *rc) {
+  mma_f6f6f32_16_8_32_((float *)data);
+  *rc = 0;
 }
 
-__global__ void mma_mxf6mxf6f32_16_8_32(void *data, int *rc)
-{
-    mma_mxf6mxf6f32_16_8_32_((float *)data);
-    *rc = 0;
+__global__ void mma_mxf6mxf6f32_16_8_32(void *data, int *rc) {
+  mma_mxf6mxf6f32_16_8_32_((float *)data);
+  *rc = 0;
 }
 
-__global__ void mma_mxf8mxf8f32_16_8_32(void *data, int *rc)
-{
-    mma_mxf8mxf8f32_16_8_32_((float *)data);
-    *rc = 0;
+__global__ void mma_mxf8mxf8f32_16_8_32(void *data, int *rc) {
+  mma_mxf8mxf8f32_16_8_32_((float *)data);
+  *rc = 0;
 }
 #else
-__global__ void mma_mxf4mxf4f32_16_8_64(void *data, int *rc)
-{
-    *rc = 1;
-}
+__global__ void mma_mxf4mxf4f32_16_8_64(void *data, int *rc) { *rc = 1; }
 
-__global__ void mma_nvf4nvf4f32_16_8_64(void *data, int *rc)
-{
-    *rc = 1;
-}
+__global__ void mma_nvf4nvf4f32_16_8_64(void *data, int *rc) { *rc = 1; }
 
-__global__ void mma_f4f4f16_16_8_32(void *data, int *rc)
-{
-    *rc = 1;
-}
+__global__ void mma_f4f4f16_16_8_32(void *data, int *rc) { *rc = 1; }
 
-__global__ void mma_f4f4f32_16_8_32(void *data, int *rc)
-{
-    *rc = 1;
-}
+__global__ void mma_f4f4f32_16_8_32(void *data, int *rc) { *rc = 1; }
 
-__global__ void mma_f6f6f16_16_8_32(void *data, int *rc)
-{
-    *rc = 1;
-}
+__global__ void mma_f6f6f16_16_8_32(void *data, int *rc) { *rc = 1; }
 
-__global__ void mma_f6f6f32_16_8_32(void *data, int *rc)
-{
-    *rc = 1;
-}
+__global__ void mma_f6f6f32_16_8_32(void *data, int *rc) { *rc = 1; }
 
-__global__ void mma_mxf6mxf6f32_16_8_32(void *data, int *rc)
-{
-    *rc = 1;
-}
+__global__ void mma_mxf6mxf6f32_16_8_32(void *data, int *rc) { *rc = 1; }
 
-__global__ void mma_mxf8mxf8f32_16_8_32(void *data, int *rc)
-{
-    *rc = 1;
-}
+__global__ void mma_mxf8mxf8f32_16_8_32(void *data, int *rc) { *rc = 1; }
 #endif
 
 #if __CUDA_ARCH__ >= 890
-__global__ void mma_f8f8f16_16_8_32(void *data, int *rc)
-{
-    mma_f8f8f16_16_8_32_((half *)data);
-    *rc = 0;
+__global__ void mma_f8f8f16_16_8_32(void *data, int *rc) {
+  mma_f8f8f16_16_8_32_((half *)data);
+  *rc = 0;
 }
 
-__global__ void mma_f8f8f32_16_8_32(void *data, int *rc)
-{
-    mma_f8f8f32_16_8_32_((float *)data);
-    *rc = 0;
+__global__ void mma_f8f8f32_16_8_32(void *data, int *rc) {
+  mma_f8f8f32_16_8_32_((float *)data);
+  *rc = 0;
 }
 #else
-__global__ void mma_f8f8f16_16_8_32(void *data, int *rc)
-{
-    *rc = 1;
-}
+__global__ void mma_f8f8f16_16_8_32(void *data, int *rc) { *rc = 1; }
 
-__global__ void mma_f8f8f32_16_8_32(void *data, int *rc)
-{
-    *rc = 1;
-}
+__global__ void mma_f8f8f32_16_8_32(void *data, int *rc) { *rc = 1; }
 #endif
 
-__global__ void mma_s8s8s32_16_16_16(void *data, int *rc)
-{
-    mma_<signed char, int, 16, 16, 16>((int *)data);
-    *rc = 0;
+__global__ void mma_s8s8s32_16_16_16(void *data, int *rc) {
+  mma_<signed char, int, 16, 16, 16>((int *)data);
+  *rc = 0;
 }
 
-__global__ void mma_s8s8s32_32_8_16(void *data, int *rc)
-{
-    mma_<signed char, int, 32, 8, 16>((int *)data);
-    *rc = 0;
+__global__ void mma_s8s8s32_32_8_16(void *data, int *rc) {
+  mma_<signed char, int, 32, 8, 16>((int *)data);
+  *rc = 0;
 }
 
-__global__ void mma_f16f16f16_16_16_16(void *data, int *rc)
-{
-    mma_<half, half, 16, 16, 16>((half *)data);
-    *rc = 0;
+__global__ void mma_f16f16f16_16_16_16(void *data, int *rc) {
+  mma_<half, half, 16, 16, 16>((half *)data);
+  *rc = 0;
 }
 
-__global__ void mma_f16f16f16_32_8_16(void *data, int *rc)
-{
-    mma_<half, half, 32, 8, 16>((half *)data);
-    *rc = 0;
+__global__ void mma_f16f16f16_32_8_16(void *data, int *rc) {
+  mma_<half, half, 32, 8, 16>((half *)data);
+  *rc = 0;
 }
 
-__global__ void mma_f16f16f32_16_16_16(void *data, int *rc)
-{
-    mma_<half, float, 16, 16, 16>((float *)data);
-    *rc = 0;
+__global__ void mma_f16f16f32_16_16_16(void *data, int *rc) {
+  mma_<half, float, 16, 16, 16>((float *)data);
+  *rc = 0;
 }
 
-__global__ void mma_f16f16f32_32_8_16(void *data, int *rc)
-{
-    mma_<half, float, 32, 8, 16>((float *)data);
-    *rc = 0;
+__global__ void mma_f16f16f32_32_8_16(void *data, int *rc) {
+  mma_<half, float, 32, 8, 16>((float *)data);
+  *rc = 0;
+}
+
+template <typename T> __device__ __forceinline__ void fma_peak_body(T *typed) {
+  const int idx = threadIdx.y * blockDim.x + threadIdx.x;
+  const T mul = static_cast<T>(1.0009765625);
+  const T add = static_cast<T>(0.99951171875 + 0.0001 * (threadIdx.x & 1));
+  T acc = static_cast<T>(idx + 1);
+#pragma unroll
+  for (unsigned k = 0; k < N_LOOP_INTERNAL; k++) {
+    acc = acc * mul + add;
+  }
+  typed[idx] = acc;
+}
+
+__global__ void fma_peak(void *data, int *rc) {
+  fma_peak_body(static_cast<float *>(data));
+  *rc = 0;
+}
+
+__global__ void fma_fp32(void *data, int *rc) {
+  fma_peak_body(static_cast<float *>(data));
+  *rc = 0;
+}
+
+__global__ void fma_fp64(void *data, int *rc) {
+  fma_peak_body(static_cast<double *>(data));
+  *rc = 0;
 }
 
 #if __CUDA_ARCH__ >= 800
-__global__ void mma_bf16bf16f32_16_16_16(void *data, int *rc)
-{
-    mma_<__nv_bfloat16, float, 16, 16, 16>((float *)data);
-    *rc = 0;
+__global__ void mma_bf16bf16f32_16_16_16(void *data, int *rc) {
+  mma_<__nv_bfloat16, float, 16, 16, 16>((float *)data);
+  *rc = 0;
 }
 
-__global__ void mma_bf16bf16f32_32_8_16(void *data, int *rc)
-{
-    mma_<__nv_bfloat16, float, 32, 8, 16>((float *)data);
-    *rc = 0;
+__global__ void mma_bf16bf16f32_32_8_16(void *data, int *rc) {
+  mma_<__nv_bfloat16, float, 32, 8, 16>((float *)data);
+  *rc = 0;
 }
 
-__global__ void mma_tf32tf32f32_16_16_8(void *data, int *rc)
-{
-    mma_<precision::tf32, float, 16, 16, 8>((float *)data);
-    *rc = 0;
+__global__ void mma_tf32tf32f32_16_16_8(void *data, int *rc) {
+  mma_<precision::tf32, float, 16, 16, 8>((float *)data);
+  *rc = 0;
 }
 #else
-__global__ void mma_bf16bf16f32_16_16_16(void *data, int *rc)
-{
-    *rc = 1;
-}
+__global__ void mma_bf16bf16f32_16_16_16(void *data, int *rc) { *rc = 1; }
 
-__global__ void mma_bf16bf16f32_32_8_16(void *data, int *rc)
-{
-    *rc = 1;
-}
+__global__ void mma_bf16bf16f32_32_8_16(void *data, int *rc) { *rc = 1; }
 
-__global__ void mma_tf32tf32f32_16_16_8(void *data, int *rc)
-{
-    *rc = 1;
-}
+__global__ void mma_tf32tf32f32_16_16_8(void *data, int *rc) { *rc = 1; }
 #endif
 
 #define cudaCheckError() cudaCheckError_(__FILE__, __LINE__)
-inline void cudaCheckError_(const char *file, int line)
-{
-    cudaError_t err = cudaGetLastError();
-    if (err != cudaSuccess)
-    {
-        printf("%s in %s at line %d\n", cudaGetErrorString(err), file, line);
-        exit(EXIT_FAILURE);
-    }
+inline void cudaCheckError_(const char *file, int line) {
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    printf("%s in %s at line %d\n", cudaGetErrorString(err), file, line);
+    exit(EXIT_FAILURE);
+  }
 }
 
 template <typename OutputType, unsigned M, unsigned N, unsigned K>
-void run(void *kernel, float targetTime)
-{
-    const int num_tb = 512;
-    const int num_warps_per_tb = 4;
-    const int warp_size = 32;
-    dim3 grid(num_tb);
-    dim3 block(warp_size, num_warps_per_tb);
-    cudaStream_t stream;
-    cudaStreamCreate(&stream);
-    cudaCheckError();
-    cudaEvent_t start, stop;
-    cudaEventCreate(&start);
-    cudaEventCreate(&stop);
-    cudaCheckError();
-    void *data = nullptr;
-    size_t nbytes = num_warps_per_tb * M * N * sizeof(OutputType);
-    cudaMalloc(&data, nbytes);
-    cudaCheckError();
+void run(void *kernel, float targetTime) {
+  const int num_tb = 512;
+  const int num_warps_per_tb = 4;
+  const int warp_size = 32;
+  dim3 grid(num_tb);
+  dim3 block(warp_size, num_warps_per_tb);
+  cudaStream_t stream;
+  cudaStreamCreate(&stream);
+  cudaCheckError();
+  cudaEvent_t start, stop;
+  cudaEventCreate(&start);
+  cudaEventCreate(&stop);
+  cudaCheckError();
+  void *data = nullptr;
+  size_t nbytes = num_warps_per_tb * M * N * sizeof(OutputType);
+  cudaMalloc(&data, nbytes);
+  cudaCheckError();
 
-    int *d_rc;
-    cudaMalloc(&d_rc, sizeof(int));
-    ((void (*)(void *, int *))kernel)<<<grid, block, 0, stream>>>(data, d_rc);
-    int h_rc = 0;
-    cudaMemcpy(&h_rc, d_rc, sizeof(int), cudaMemcpyDeviceToHost);
-    if (h_rc != 0)
-    {
-        printf("not supported\n");
+  int *d_rc;
+  cudaMalloc(&d_rc, sizeof(int));
+  ((void (*)(void *, int *))kernel)<<<grid, block, 0, stream>>>(data, d_rc);
+  int h_rc = 0;
+  cudaMemcpy(&h_rc, d_rc, sizeof(int), cudaMemcpyDeviceToHost);
+  if (h_rc != 0) {
+    printf("not supported\n");
+  } else {
+    int n_loop = N_LOOP_CALIB;
+    cudaCheckError();
+    cudaEventRecord(start, stream);
+    for (int i = 0; i < n_loop; i++) {
+      ((void (*)(void *, int *))kernel)<<<grid, block, 0, stream>>>(data, d_rc);
     }
-    else
-    {
-        int n_loop = N_LOOP_CALIB;
-        cudaCheckError();
-        cudaEventRecord(start, stream);
-        for (int i = 0; i < n_loop; i++)
-        {
-            ((void (*)(void *, int *))kernel)<<<grid, block, 0, stream>>>(data, d_rc);
-        }
-        cudaCheckError();
-        cudaEventRecord(stop, stream);
-        cudaEventSynchronize(stop);
-        float ms;
-        cudaEventElapsedTime(&ms, start, stop);
-
-        n_loop = (int)(targetTime * 1000 / ms * n_loop);
-        n_loop = n_loop > 0 ? n_loop : N_LOOP_CALIB;
-
-        cudaEventRecord(start, stream);
-        for (int i = 0; i < n_loop; i++)
-        {
-            ((void (*)(void *, int *))kernel)<<<grid, block, 0, stream>>>(data, d_rc);
-        }
-        cudaCheckError();
-        cudaEventRecord(stop, stream);
-        cudaEventSynchronize(stop);
-        cudaStreamDestroy(stream);
-        cudaCheckError();
-        cudaEventElapsedTime(&ms, start, stop);
-        float ops = 1.0f * num_tb * num_warps_per_tb * n_loop * N_LOOP_INTERNAL * M * N * K * 2;
-        printf("%s: %.1f ms %.1f T(fl)ops\n", __func__, ms, ops / ms / 1.0e9f);
-    }
-    cudaFree(d_rc);
-    cudaFree(data);
     cudaCheckError();
+    cudaEventRecord(stop, stream);
+    cudaEventSynchronize(stop);
+    float ms;
+    cudaEventElapsedTime(&ms, start, stop);
+
+    n_loop = (int)(targetTime * 1000 / ms * n_loop);
+    n_loop = n_loop > 0 ? n_loop : N_LOOP_CALIB;
+
+    cudaEventRecord(start, stream);
+    for (int i = 0; i < n_loop; i++) {
+      ((void (*)(void *, int *))kernel)<<<grid, block, 0, stream>>>(data, d_rc);
+    }
+    cudaCheckError();
+    cudaEventRecord(stop, stream);
+    cudaEventSynchronize(stop);
+    cudaStreamDestroy(stream);
+    cudaCheckError();
+    cudaEventElapsedTime(&ms, start, stop);
+    float ops = 1.0f * num_tb * num_warps_per_tb * n_loop * N_LOOP_INTERNAL *
+                M * N * K * 2;
+    printf("%s: %.1f ms %.1f T(fl)ops\n", __func__, ms, ops / ms / 1.0e9f);
+  }
+  cudaFree(d_rc);
+  cudaFree(data);
+  cudaCheckError();
 }
 
-void print_usage()
-{
-    printf("Usage: mmapeak [options]\n");
-    printf("Options:\n");
-    printf("  -t <seconds>   Set target time for benchmarks in seconds (default: %.1f)\n", DEFAULT_TARGET_TIME);
-    printf("  -h, --help     Show this help message\n");
+template <typename OutputType>
+void run_fma(void *kernel, const char *label, float targetTime) {
+  const int num_tb = 512;
+  const int num_warps_per_tb = 4;
+  const int warp_size = 32;
+  dim3 grid(num_tb);
+  dim3 block(warp_size, num_warps_per_tb);
+  cudaStream_t stream;
+  cudaStreamCreate(&stream);
+  cudaCheckError();
+  cudaEvent_t start, stop;
+  cudaEventCreate(&start);
+  cudaEventCreate(&stop);
+  cudaCheckError();
+  void *data = nullptr;
+  size_t nbytes = num_warps_per_tb * warp_size * sizeof(OutputType);
+  cudaMalloc(&data, nbytes);
+  cudaCheckError();
+
+  int *d_rc;
+  cudaMalloc(&d_rc, sizeof(int));
+  ((void (*)(void *, int *))kernel)<<<grid, block, 0, stream>>>(data, d_rc);
+  int h_rc = 0;
+  cudaMemcpy(&h_rc, d_rc, sizeof(int), cudaMemcpyDeviceToHost);
+  if (h_rc != 0) {
+    printf("not supported\n");
+  } else {
+    int n_loop = N_LOOP_CALIB;
+    cudaCheckError();
+    cudaEventRecord(start, stream);
+    for (int i = 0; i < n_loop; i++) {
+      ((void (*)(void *, int *))kernel)<<<grid, block, 0, stream>>>(data, d_rc);
+    }
+    cudaCheckError();
+    cudaEventRecord(stop, stream);
+    cudaEventSynchronize(stop);
+    float ms;
+    cudaEventElapsedTime(&ms, start, stop);
+
+    n_loop = (int)(targetTime * 1000 / ms * n_loop);
+    n_loop = n_loop > 0 ? n_loop : N_LOOP_CALIB;
+
+    cudaEventRecord(start, stream);
+    for (int i = 0; i < n_loop; i++) {
+      ((void (*)(void *, int *))kernel)<<<grid, block, 0, stream>>>(data, d_rc);
+    }
+    cudaCheckError();
+    cudaEventRecord(stop, stream);
+    cudaEventSynchronize(stop);
+    cudaStreamDestroy(stream);
+    cudaCheckError();
+    cudaEventElapsedTime(&ms, start, stop);
+    float ops =
+        1.0f * num_tb * block.x * block.y * n_loop * N_LOOP_INTERNAL * 2;
+    printf("%s: %.1f ms %.1f T(fl)ops\n", label, ms, ops / ms / 1.0e9f);
+  }
+  cudaFree(d_rc);
+  cudaFree(data);
+  cudaCheckError();
 }
 
-int main(int argc, char **argv)
-{
-    float targetTime = DEFAULT_TARGET_TIME;
+inline void print_heading(const char *title, char separator) {
+  printf("\n");
+  for (int i = 0; i < 40; i++) {
+    putchar(separator);
+  }
+  printf(" %s ", title);
+  for (int i = 0; i < 40; i++) {
+    putchar(separator);
+  }
+  printf("\n");
+}
 
-    // Parse command line arguments
-    for (int i = 1; i < argc; i++)
-    {
-        if (strcmp(argv[i], "-t") == 0 && i + 1 < argc)
-        {
-            targetTime = atof(argv[++i]);
-            if (targetTime <= 0)
-            {
-                printf("Error: Target time must be positive\n");
-                print_usage();
-                return 1;
-            }
-        }
-        else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0)
-        {
-            print_usage();
-            return 0;
-        }
-        else
-        {
-            printf("Unknown option: %s\n", argv[i]);
-            print_usage();
-            return 1;
-        }
-    }
+void print_usage() {
+  printf("Usage: mmapeak [options]\n");
+  printf("Options:\n");
+  printf("  -t <seconds>   Set target time for benchmarks in seconds (default: "
+         "%.1f)\n",
+         DEFAULT_TARGET_TIME);
+  printf("  -h, --help     Show this help message\n");
+}
 
-    int deviceCount;
-    cudaGetDeviceCount(&deviceCount);
-    cudaCheckError();
-    if (deviceCount == 0)
-    {
-        printf("No CUDA devices found\n");
+int main(int argc, char **argv) {
+  float targetTime = DEFAULT_TARGET_TIME;
+
+  // Parse command line arguments
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "-t") == 0 && i + 1 < argc) {
+      targetTime = atof(argv[++i]);
+      if (targetTime <= 0) {
+        printf("Error: Target time must be positive\n");
+        print_usage();
         return 1;
+      }
+    } else if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
+      print_usage();
+      return 0;
+    } else {
+      printf("Unknown option: %s\n", argv[i]);
+      print_usage();
+      return 1;
     }
-    for (int i = 0; i < deviceCount; i++)
-    {
-        printf("----------------------------------------\n");
+  }
 
-        cudaDeviceProp prop;
-        cudaGetDeviceProperties(&prop, i);
-        cudaCheckError();
-        printf("Device %d: %s\n", i, prop.name);
-        printf("  Compute capability: %d.%d\n", prop.major, prop.minor);
-        printf("  Total global memory: %.1f GiB\n", prop.totalGlobalMem / (1024.0 * 1024.0 * 1024.0));
-        printf("  Multiprocessor count: %d\n", prop.multiProcessorCount);
+  int deviceCount;
+  cudaGetDeviceCount(&deviceCount);
+  cudaCheckError();
+  if (deviceCount == 0) {
+    printf("No CUDA devices found\n");
+    return 1;
+  }
+  for (int i = 0; i < deviceCount; i++) {
+    printf("----------------------------------------\n");
 
-        cudaSetDevice(i);
-        cudaCheckError();
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, i);
+    cudaCheckError();
+    printf("Device %d: %s\n", i, prop.name);
+    printf("  Compute capability: %d.%d\n", prop.major, prop.minor);
+    printf("  Total global memory: %.1f GiB\n",
+           prop.totalGlobalMem / (1024.0 * 1024.0 * 1024.0));
+    printf("  Multiprocessor count: %d\n", prop.multiProcessorCount);
 
-        printf("Running benchmarks with target time: %.1f seconds\n", targetTime);
-        printf("mma_s4s4s32_8_8_32\n");
-        run<int, 8, 8, 32>((void *)mma_s4s4s32_8_8_32, targetTime);
-        printf("mma_mxf4mxf4f32_16_8_64\n");
-        run<float, 16, 8, 64>((void *)mma_mxf4mxf4f32_16_8_64, targetTime);
-        printf("mma_nvf4nvf4f32_16_8_64\n");
-        run<float, 16, 8, 64>((void *)mma_nvf4nvf4f32_16_8_64, targetTime);
-        printf("mma_f4f4f16_16_8_32\n");
-        run<half, 16, 8, 32>((void *)mma_f4f4f16_16_8_32, targetTime);
-        printf("mma_f4f4f32_16_8_32\n");
-        run<float, 16, 8, 32>((void *)mma_f4f4f32_16_8_32, targetTime);
-        printf("mma_f6f6f16_16_8_32\n");
-        run<half, 16, 8, 32>((void *)mma_f6f6f16_16_8_32, targetTime);
-        printf("mma_f6f6f32_16_8_32\n");
-        run<float, 16, 8, 32>((void *)mma_f6f6f32_16_8_32, targetTime);
-        printf("mma_mxf6mxf6f32_16_8_32\n");
-        run<float, 16, 8, 32>((void *)mma_mxf6mxf6f32_16_8_32, targetTime);
-        printf("mma_mxf8mxf8f32_16_8_32\n");
-        run<float, 16, 8, 32>((void *)mma_mxf8mxf8f32_16_8_32, targetTime);
-        printf("mma_f8f8f16_16_8_32\n");
-        run<half, 16, 8, 32>((void *)mma_f8f8f16_16_8_32, targetTime);
-        printf("mma_f8f8f32_16_8_32\n");
-        run<float, 16, 8, 32>((void *)mma_f8f8f32_16_8_32, targetTime);
-        printf("mma_s8s8s32_16_16_16\n");
-        run<int, 16, 16, 16>((void *)mma_s8s8s32_16_16_16, targetTime);
-        printf("mma_s8s8s32_32_8_16\n");
-        run<int, 32, 8, 16>((void *)mma_s8s8s32_32_8_16, targetTime);
-        printf("mma_f16f16f16_16_16_16\n");
-        run<half, 16, 16, 16>((void *)mma_f16f16f16_16_16_16, targetTime);
-        printf("mma_f16f16f16_32_8_16\n");
-        run<half, 32, 8, 16>((void *)mma_f16f16f16_32_8_16, targetTime);
-        printf("mma_f16f16f32_16_16_16\n");
-        run<float, 16, 16, 16>((void *)mma_f16f16f32_16_16_16, targetTime);
-        printf("mma_f16f16f32_32_8_16\n");
-        run<float, 32, 8, 16>((void *)mma_f16f16f32_32_8_16, targetTime);
-        printf("mma_bf16bf16f32_16_16_16\n");
-        run<float, 16, 16, 16>((void *)mma_bf16bf16f32_16_16_16, targetTime);
-        printf("mma_bf16bf16f32_32_8_16\n");
-        run<float, 32, 8, 16>((void *)mma_bf16bf16f32_32_8_16, targetTime);
-        printf("mma_tf32tf32f32_16_16_8\n");
-        run<float, 16, 16, 8>((void *)mma_tf32tf32f32_16_16_8, targetTime);
-    }
-    return 0;
+    cudaSetDevice(i);
+    cudaCheckError();
+
+    printf("Running benchmarks with target time: %.1f seconds\n", targetTime);
+
+    print_heading("INT", '=');
+    printf("- mma_s4s4s32_8_8_32\n");
+    run<int, 8, 8, 32>((void *)mma_s4s4s32_8_8_32, targetTime);
+    printf("- mma_s8s8s32_16_16_16\n");
+    run<int, 16, 16, 16>((void *)mma_s8s8s32_16_16_16, targetTime);
+    printf("- mma_s8s8s32_32_8_16\n");
+    run<int, 32, 8, 16>((void *)mma_s8s8s32_32_8_16, targetTime);
+
+    print_heading("FP4", '-');
+    printf("- mma_mxf4mxf4f32_16_8_64\n");
+    run<float, 16, 8, 64>((void *)mma_mxf4mxf4f32_16_8_64, targetTime);
+    printf("- mma_nvf4nvf4f32_16_8_64\n");
+    run<float, 16, 8, 64>((void *)mma_nvf4nvf4f32_16_8_64, targetTime);
+    printf("- mma_f4f4f16_16_8_32\n");
+    run<half, 16, 8, 32>((void *)mma_f4f4f16_16_8_32, targetTime);
+    printf("- mma_f4f4f32_16_8_32\n");
+    run<float, 16, 8, 32>((void *)mma_f4f4f32_16_8_32, targetTime);
+
+    print_heading("FP6", '-');
+    printf("- mma_f6f6f16_16_8_32\n");
+    run<half, 16, 8, 32>((void *)mma_f6f6f16_16_8_32, targetTime);
+    printf("- mma_f6f6f32_16_8_32\n");
+    run<float, 16, 8, 32>((void *)mma_f6f6f32_16_8_32, targetTime);
+    printf("- mma_mxf6mxf6f32_16_8_32\n");
+    run<float, 16, 8, 32>((void *)mma_mxf6mxf6f32_16_8_32, targetTime);
+
+    print_heading("FP8", '-');
+    printf("- mma_mxf8mxf8f32_16_8_32\n");
+    run<float, 16, 8, 32>((void *)mma_mxf8mxf8f32_16_8_32, targetTime);
+    printf("- mma_f8f8f16_16_8_32\n");
+    run<half, 16, 8, 32>((void *)mma_f8f8f16_16_8_32, targetTime);
+    printf("- mma_f8f8f32_16_8_32\n");
+    run<float, 16, 8, 32>((void *)mma_f8f8f32_16_8_32, targetTime);
+
+    print_heading("FP16", '-');
+    printf("- mma_f16f16f16_16_16_16\n");
+    run<half, 16, 16, 16>((void *)mma_f16f16f16_16_16_16, targetTime);
+    printf("- mma_f16f16f16_32_8_16\n");
+    run<half, 32, 8, 16>((void *)mma_f16f16f16_32_8_16, targetTime);
+    printf("- mma_f16f16f32_16_16_16\n");
+    run<float, 16, 16, 16>((void *)mma_f16f16f32_16_16_16, targetTime);
+    printf("- mma_f16f16f32_32_8_16\n");
+    run<float, 32, 8, 16>((void *)mma_f16f16f32_32_8_16, targetTime);
+    printf("- mma_bf16bf16f32_16_16_16\n");
+    run<float, 16, 16, 16>((void *)mma_bf16bf16f32_16_16_16, targetTime);
+    printf("- mma_bf16bf16f32_32_8_16\n");
+    run<float, 32, 8, 16>((void *)mma_bf16bf16f32_32_8_16, targetTime);
+
+    print_heading("FP32", '-');
+    printf("- mma_tf32tf32f32_16_16_8\n");
+    run<float, 16, 16, 8>((void *)mma_tf32tf32f32_16_16_8, targetTime);
+    printf("- fma_fp32 (scalar)\n");
+    run_fma<float>((void *)fma_fp32, "fma_fp32", targetTime);
+
+    print_heading("FP64", '-');
+    printf("- fma_fp64 (scalar)\n");
+    run_fma<double>((void *)fma_fp64, "fma_fp64", targetTime);
+  }
+  return 0;
 }


### PR DESCRIPTION
example output:

```text
----------------------------------------
Device 0: NVIDIA GeForce RTX 4080
  Compute capability: 8.9
  Total global memory: 15.6 GiB
  Multiprocessor count: 76
Running benchmarks with target time: 3.0 seconds

======================================== INT ========================================
- mma_s4s4s32_8_8_32
run: 2709.2 ms 679.3 T(fl)ops
- mma_s8s8s32_16_16_16
run: 2999.5 ms 408.6 T(fl)ops
- mma_s8s8s32_32_8_16
run: 2999.9 ms 408.6 T(fl)ops

---------------------------------------- FP4 ----------------------------------------
- mma_mxf4mxf4f32_16_8_64
not supported
- mma_nvf4nvf4f32_16_8_64
not supported
- mma_f4f4f16_16_8_32
not supported
- mma_f4f4f32_16_8_32
not supported

---------------------------------------- FP6 ----------------------------------------
- mma_f6f6f16_16_8_32
not supported
- mma_f6f6f32_16_8_32
not supported
- mma_mxf6mxf6f32_16_8_32
not supported

---------------------------------------- FP8 ----------------------------------------
- mma_mxf8mxf8f32_16_8_32
not supported
- mma_f8f8f16_16_8_32
run: 2999.9 ms 391.0 T(fl)ops
- mma_f8f8f32_16_8_32
run: 2999.6 ms 209.4 T(fl)ops

---------------------------------------- FP16 ----------------------------------------
- mma_f16f16f16_16_16_16
run: 2999.6 ms 210.4 T(fl)ops
- mma_f16f16f16_32_8_16
run: 2999.8 ms 210.4 T(fl)ops
- mma_f16f16f32_16_16_16
run: 2999.8 ms 105.3 T(fl)ops
- mma_f16f16f32_32_8_16
run: 3000.0 ms 105.3 T(fl)ops
- mma_bf16bf16f32_16_16_16
run: 2999.1 ms 105.0 T(fl)ops
- mma_bf16bf16f32_32_8_16
run: 2999.1 ms 105.0 T(fl)ops

---------------------------------------- FP32 ----------------------------------------
- mma_tf32tf32f32_16_16_8
run: 2999.8 ms 52.5 T(fl)ops
- fma_fp32 (scalar)
fma_fp32: 3016.1 ms 41.8 T(fl)ops

---------------------------------------- FP64 ----------------------------------------
- fma_fp64 (scalar)
fma_fp64: 2993.1 ms 0.7 T(fl)ops
```